### PR TITLE
Update to bootstrap 4.1

### DIFF
--- a/UltiSnips/html_bootstrap4_templates.snippets
+++ b/UltiSnips/html_bootstrap4_templates.snippets
@@ -8,16 +8,17 @@ snippet htmlb4
 		<meta http-equiv="x-ua-compatible" content="ie=edge">
 		<title>$1</title>
 
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
 	</head>
 	<body>
 		<h1>${3:Hello, world!}</h1>
 
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
+		<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
 	</body>
 	</html>
-endsnippet
+
 
 # Carousel template - Bootstrap 4
 snippet htmlca
@@ -238,7 +239,7 @@ snippet htmlca
 			</svg>
 		</body>
 	</html>
-endsnippet
+
 
 # Cover template - Bootstrap 4
 snippet htmlco
@@ -313,9 +314,10 @@ snippet htmlco
 			<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 			<script src="http://v4-alpha.getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Dashboard template - Bootstrap 4
 snippet htmlda
@@ -560,9 +562,10 @@ snippet htmlda
 			<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 			<script src="http://v4-alpha.getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Grids template - Bootstrap 4
 snippet htmlgd
@@ -740,13 +743,15 @@ snippet htmlgd
 
 			</div> <!-- /container -->
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Jumbotron template - Bootstrap 4
 snippet htmljb
@@ -811,7 +816,7 @@ snippet htmljb
 						<h2>Heading</h2>
 						<p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
 						<p><a class="btn btn-secondary" href="#" role="button">View details »</a></p>
-					</div>
+				 </div>
 					<div class="col-md-4">
 						<h2>Heading</h2>
 						<p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
@@ -826,6 +831,7 @@ snippet htmljb
 				</footer>
 			</div> <!-- /container -->
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
@@ -833,9 +839,10 @@ snippet htmljb
 			<script>window.jQuery || document.write('<script src="http://v4-alpha.getbootstrap.com/assets/js/vendor/jquery.min.js"><\/script>')</script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Navbar template - Bootstrap 4
 snippet htmlnb
@@ -889,6 +896,7 @@ snippet htmlnb
 
 			</div> <!-- /container -->
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
@@ -896,9 +904,10 @@ snippet htmlnb
 			<script>window.jQuery || document.write('<script src="http://v4-alpha.getbootstrap.com/assets/js/vendor/jquery.min.js"><\/script>')</script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Fixed Navbar template - Bootstrap 4
 snippet htmlnbfx
@@ -948,15 +957,17 @@ snippet htmlnbfx
 				</div>
 			</div>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 			<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Justified nav template - Bootstrap 4
 snippet htmlnbj
@@ -988,7 +999,7 @@ snippet htmlnbj
 			<div class="container">
 
 				<!-- The justified navigation menu is meant for single line per list item.
-						Multiple lines will require custom code not provided by Bootstrap. -->
+						 Multiple lines will require custom code not provided by Bootstrap. -->
 				<div class="masthead">
 					<h3 class="text-muted">Project name</h3>
 					<nav>
@@ -1022,7 +1033,7 @@ snippet htmlnbj
 						<h2>Heading</h2>
 						<p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
 						<p><a class="btn btn-primary" href="#" role="button">View details »</a></p>
-					</div>
+				 </div>
 					<div class="col-lg-4">
 						<h2>Heading</h2>
 						<p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa.</p>
@@ -1037,13 +1048,15 @@ snippet htmlnbj
 
 			</div> <!-- /container -->
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Static top Navbar template - Bootstrap 4
 snippet htmlnbst
@@ -1091,15 +1104,17 @@ snippet htmlnbst
 				</div>
 			</div>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 			<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Sticky footer template - Bootstrap 4
 snippet htmlsf
@@ -1143,13 +1158,15 @@ snippet htmlsf
 				</div>
 			</footer>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Sticky footer w/ navbar template - Bootstrap 4
 snippet htmlsfn
@@ -1227,6 +1244,7 @@ snippet htmlsfn
 				</div>
 			</footer>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
@@ -1234,9 +1252,10 @@ snippet htmlsfn
 			<script>window.jQuery || document.write('<script src="http://v4-alpha.getbootstrap.com/assets/js/vendor/jquery.min.js"><\/script>')</script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Sign-in template - Bootstrap 4
 snippet htmlsi
@@ -1283,13 +1302,15 @@ snippet htmlsi
 
 		</div> <!-- /container -->
 
+
 		<!-- Bootstrap core JavaScript
 		================================================== -->
 		<!-- Placed at the end of the document so the pages load faster -->
 
+
 	</body>
 	</html>
-endsnippet
+
 
 # Blog template - Bootstrap 4
 snippet htmlbl
@@ -1454,6 +1475,7 @@ snippet htmlbl
 				</p>
 			</footer>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
@@ -1462,9 +1484,11 @@ snippet htmlbl
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 			<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 			<script src="http://v4-alpha.getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
+
+
 		</body>
 	</html>
-endsnippet
+
 
 # Starter template - Bootstrap 4
 snippet htmlst
@@ -1518,38 +1542,40 @@ snippet htmlst
 			<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
 		</body>
 	</html>
-endsnippet
+
 
 # CSS & JS\'s CDN - Bootstrap 4
 snippet cdn-b4
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/${2:2.1.4}/jquery.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
-endsnippet
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
+	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+
+
+
 
 # CSS \'s CDN - Bootstrap 4
 snippet cdncs
 	<!-- Bootstrap CSS -->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
-endsnippet
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
+
 
 # JS \'s CDN - Bootstrap 4
 snippet cdnjs
-	<!-- jQuery first, then Bootstrap JS. -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/${1:2.1.4}/jquery.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
-endsnippet
+	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+
 
 # Local CSS - Bootstrap 4
 snippet loccs
 	<!-- Bootstrap CSS -->
 	<link rel="stylesheet" href="$1/css/bootstrap.css">
-endsnippet
+
 
 # Local JS - Bootstrap 4
 snippet locjs
-	<!-- jQuery first, then Bootstrap JS. -->
 	<script src="$1/js/jquery.min.js"></script>
+	<script src="$1/js/tether.min.js"></script>
 	<script src="$1/js/bootstrap.js"></script>
-endsnippet
 

--- a/UltiSnips/html_bootstrap4_templates.snippets
+++ b/UltiSnips/html_bootstrap4_templates.snippets
@@ -18,7 +18,7 @@ snippet htmlb4
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
 	</body>
 	</html>
-
+endsnippet
 
 # Carousel template - Bootstrap 4
 snippet htmlca
@@ -239,7 +239,7 @@ snippet htmlca
 			</svg>
 		</body>
 	</html>
-
+endsnippet
 
 # Cover template - Bootstrap 4
 snippet htmlco
@@ -317,7 +317,7 @@ snippet htmlco
 
 		</body>
 	</html>
-
+endsnippet
 
 # Dashboard template - Bootstrap 4
 snippet htmlda
@@ -565,7 +565,7 @@ snippet htmlda
 
 		</body>
 	</html>
-
+endsnippet
 
 # Grids template - Bootstrap 4
 snippet htmlgd
@@ -751,7 +751,7 @@ snippet htmlgd
 
 		</body>
 	</html>
-
+endsnippet
 
 # Jumbotron template - Bootstrap 4
 snippet htmljb
@@ -842,7 +842,7 @@ snippet htmljb
 
 		</body>
 	</html>
-
+endsnippet
 
 # Navbar template - Bootstrap 4
 snippet htmlnb
@@ -907,7 +907,7 @@ snippet htmlnb
 
 		</body>
 	</html>
-
+endsnippet
 
 # Fixed Navbar template - Bootstrap 4
 snippet htmlnbfx
@@ -967,7 +967,7 @@ snippet htmlnbfx
 
 		</body>
 	</html>
-
+endsnippet
 
 # Justified nav template - Bootstrap 4
 snippet htmlnbj
@@ -1056,7 +1056,7 @@ snippet htmlnbj
 
 		</body>
 	</html>
-
+endsnippet
 
 # Static top Navbar template - Bootstrap 4
 snippet htmlnbst
@@ -1114,7 +1114,7 @@ snippet htmlnbst
 
 		</body>
 	</html>
-
+endsnippet
 
 # Sticky footer template - Bootstrap 4
 snippet htmlsf
@@ -1166,7 +1166,7 @@ snippet htmlsf
 
 		</body>
 	</html>
-
+endsnippet
 
 # Sticky footer w/ navbar template - Bootstrap 4
 snippet htmlsfn
@@ -1255,7 +1255,7 @@ snippet htmlsfn
 
 		</body>
 	</html>
-
+endsnippet
 
 # Sign-in template - Bootstrap 4
 snippet htmlsi
@@ -1310,7 +1310,7 @@ snippet htmlsi
 
 	</body>
 	</html>
-
+endsnippet
 
 # Blog template - Bootstrap 4
 snippet htmlbl
@@ -1488,7 +1488,7 @@ snippet htmlbl
 
 		</body>
 	</html>
-
+endsnippet
 
 # Starter template - Bootstrap 4
 snippet htmlst
@@ -1542,7 +1542,7 @@ snippet htmlst
 			<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
 		</body>
 	</html>
-
+endsnippet
 
 # CSS & JS\'s CDN - Bootstrap 4
 snippet cdn-b4
@@ -1550,32 +1550,30 @@ snippet cdn-b4
 	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
-
-
-
+endsnippet
 
 # CSS \'s CDN - Bootstrap 4
 snippet cdncs
 	<!-- Bootstrap CSS -->
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
-
+endsnippet
 
 # JS \'s CDN - Bootstrap 4
 snippet cdnjs
 	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
-
+endsnippet
 
 # Local CSS - Bootstrap 4
 snippet loccs
 	<!-- Bootstrap CSS -->
 	<link rel="stylesheet" href="$1/css/bootstrap.css">
-
+endsnippet
 
 # Local JS - Bootstrap 4
 snippet locjs
 	<script src="$1/js/jquery.min.js"></script>
 	<script src="$1/js/tether.min.js"></script>
 	<script src="$1/js/bootstrap.js"></script>
-
+endsnippet

--- a/html/bootstrap4.templates.snippets
+++ b/html/bootstrap4.templates.snippets
@@ -8,13 +8,14 @@ snippet htmlb4
 		<meta http-equiv="x-ua-compatible" content="ie=edge">
 		<title>$1</title>
 
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
 	</head>
 	<body>
 		<h1>${3:Hello, world!}</h1>
 
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
+		<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
 	</body>
 	</html>
 
@@ -1545,22 +1546,25 @@ snippet htmlst
 
 # CSS & JS\'s CDN - Bootstrap 4
 snippet cdn-b4
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/${2:2.1.4}/jquery.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
+	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+
+
 
 
 # CSS \'s CDN - Bootstrap 4
 snippet cdncs
 	<!-- Bootstrap CSS -->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
 
 
 # JS \'s CDN - Bootstrap 4
 snippet cdnjs
-	<!-- jQuery first, then Bootstrap JS. -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/${1:2.1.4}/jquery.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
+	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
 
 
 # Local CSS - Bootstrap 4
@@ -1571,7 +1575,7 @@ snippet loccs
 
 # Local JS - Bootstrap 4
 snippet locjs
-	<!-- jQuery first, then Bootstrap JS. -->
 	<script src="$1/js/jquery.min.js"></script>
+	<script src="$1/js/tether.min.js"></script>
 	<script src="$1/js/bootstrap.js"></script>
 

--- a/snippets/html_bootstrap4_templates.snippets
+++ b/snippets/html_bootstrap4_templates.snippets
@@ -8,16 +8,17 @@ snippet htmlb4
 		<meta http-equiv="x-ua-compatible" content="ie=edge">
 		<title>$1</title>
 
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
 	</head>
 	<body>
 		<h1>${3:Hello, world!}</h1>
 
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
+		<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
 	</body>
 	</html>
-endsnippet
+
 
 # Carousel template - Bootstrap 4
 snippet htmlca
@@ -238,7 +239,7 @@ snippet htmlca
 			</svg>
 		</body>
 	</html>
-endsnippet
+
 
 # Cover template - Bootstrap 4
 snippet htmlco
@@ -313,9 +314,10 @@ snippet htmlco
 			<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 			<script src="http://v4-alpha.getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Dashboard template - Bootstrap 4
 snippet htmlda
@@ -560,9 +562,10 @@ snippet htmlda
 			<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 			<script src="http://v4-alpha.getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Grids template - Bootstrap 4
 snippet htmlgd
@@ -740,13 +743,15 @@ snippet htmlgd
 
 			</div> <!-- /container -->
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Jumbotron template - Bootstrap 4
 snippet htmljb
@@ -811,7 +816,7 @@ snippet htmljb
 						<h2>Heading</h2>
 						<p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
 						<p><a class="btn btn-secondary" href="#" role="button">View details »</a></p>
-					</div>
+				 </div>
 					<div class="col-md-4">
 						<h2>Heading</h2>
 						<p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</p>
@@ -826,6 +831,7 @@ snippet htmljb
 				</footer>
 			</div> <!-- /container -->
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
@@ -833,9 +839,10 @@ snippet htmljb
 			<script>window.jQuery || document.write('<script src="http://v4-alpha.getbootstrap.com/assets/js/vendor/jquery.min.js"><\/script>')</script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Navbar template - Bootstrap 4
 snippet htmlnb
@@ -889,6 +896,7 @@ snippet htmlnb
 
 			</div> <!-- /container -->
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
@@ -896,9 +904,10 @@ snippet htmlnb
 			<script>window.jQuery || document.write('<script src="http://v4-alpha.getbootstrap.com/assets/js/vendor/jquery.min.js"><\/script>')</script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Fixed Navbar template - Bootstrap 4
 snippet htmlnbfx
@@ -948,15 +957,17 @@ snippet htmlnbfx
 				</div>
 			</div>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 			<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Justified nav template - Bootstrap 4
 snippet htmlnbj
@@ -988,7 +999,7 @@ snippet htmlnbj
 			<div class="container">
 
 				<!-- The justified navigation menu is meant for single line per list item.
-						Multiple lines will require custom code not provided by Bootstrap. -->
+						 Multiple lines will require custom code not provided by Bootstrap. -->
 				<div class="masthead">
 					<h3 class="text-muted">Project name</h3>
 					<nav>
@@ -1022,7 +1033,7 @@ snippet htmlnbj
 						<h2>Heading</h2>
 						<p>Donec id elit non mi porta gravida at eget metus. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Etiam porta sem malesuada magna mollis euismod. Donec sed odio dui. </p>
 						<p><a class="btn btn-primary" href="#" role="button">View details »</a></p>
-					</div>
+				 </div>
 					<div class="col-lg-4">
 						<h2>Heading</h2>
 						<p>Donec sed odio dui. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa.</p>
@@ -1037,13 +1048,15 @@ snippet htmlnbj
 
 			</div> <!-- /container -->
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Static top Navbar template - Bootstrap 4
 snippet htmlnbst
@@ -1091,15 +1104,17 @@ snippet htmlnbst
 				</div>
 			</div>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 			<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Sticky footer template - Bootstrap 4
 snippet htmlsf
@@ -1143,13 +1158,15 @@ snippet htmlsf
 				</div>
 			</footer>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Sticky footer w/ navbar template - Bootstrap 4
 snippet htmlsfn
@@ -1227,6 +1244,7 @@ snippet htmlsfn
 				</div>
 			</footer>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
@@ -1234,9 +1252,10 @@ snippet htmlsfn
 			<script>window.jQuery || document.write('<script src="http://v4-alpha.getbootstrap.com/assets/js/vendor/jquery.min.js"><\/script>')</script>
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 
+
 		</body>
 	</html>
-endsnippet
+
 
 # Sign-in template - Bootstrap 4
 snippet htmlsi
@@ -1283,13 +1302,15 @@ snippet htmlsi
 
 		</div> <!-- /container -->
 
+
 		<!-- Bootstrap core JavaScript
 		================================================== -->
 		<!-- Placed at the end of the document so the pages load faster -->
 
+
 	</body>
 	</html>
-endsnippet
+
 
 # Blog template - Bootstrap 4
 snippet htmlbl
@@ -1454,6 +1475,7 @@ snippet htmlbl
 				</p>
 			</footer>
 
+
 			<!-- Bootstrap core JavaScript
 			================================================== -->
 			<!-- Placed at the end of the document so the pages load faster -->
@@ -1462,9 +1484,11 @@ snippet htmlbl
 			<script src="http://v4-alpha.getbootstrap.com/dist/js/bootstrap.min.js"></script>
 			<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
 			<script src="http://v4-alpha.getbootstrap.com/assets/js/ie10-viewport-bug-workaround.js"></script>
+
+
 		</body>
 	</html>
-endsnippet
+
 
 # Starter template - Bootstrap 4
 snippet htmlst
@@ -1518,38 +1542,40 @@ snippet htmlst
 			<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
 		</body>
 	</html>
-endsnippet
+
 
 # CSS & JS\'s CDN - Bootstrap 4
 snippet cdn-b4
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/${2:2.1.4}/jquery.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
-endsnippet
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
+	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+
+
+
 
 # CSS \'s CDN - Bootstrap 4
 snippet cdncs
 	<!-- Bootstrap CSS -->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" integrity="sha384-y3tfxAZXuh4HwSYylfB+J125MxIs6mR5FOHamPBG064zB+AFeWH94NdvaCBm8qnd" crossorigin="anonymous">
-endsnippet
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">
+
 
 # JS \'s CDN - Bootstrap 4
 snippet cdnjs
-	<!-- jQuery first, then Bootstrap JS. -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/${1:2.1.4}/jquery.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js" integrity="sha384-vZ2WRJMwsjRMW/8U7i6PWi6AlO1L79snBrmgiDpgIWJ82z8eA5lenwvxbMV1PAh7" crossorigin="anonymous"></script>
-endsnippet
+	<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+
 
 # Local CSS - Bootstrap 4
 snippet loccs
 	<!-- Bootstrap CSS -->
 	<link rel="stylesheet" href="$1/css/bootstrap.css">
-endsnippet
+
 
 # Local JS - Bootstrap 4
 snippet locjs
-	<!-- jQuery first, then Bootstrap JS. -->
 	<script src="$1/js/jquery.min.js"></script>
+	<script src="$1/js/tether.min.js"></script>
 	<script src="$1/js/bootstrap.js"></script>
-endsnippet
 


### PR DESCRIPTION
These snippets have been using alpha2 for the longest time, so I updated them to use the CDN links from [getbootstrap.com](https://getbootstrap.com). Note that I haven't checked each individual snippet for compatibility with the changes, but I doubt much has significantly changed that would affect individual components in these snippets.